### PR TITLE
fix(android): inject missing namespace for legacy plugins

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -15,8 +15,31 @@ subprojects {
     val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
     project.layout.buildDirectory.value(newSubprojectBuildDir)
 }
+
 subprojects {
     project.evaluationDependsOn(":app")
+}
+
+subprojects {
+    project.plugins.withId("com.android.library") {
+        val androidExtension = project.extensions.findByName("android")
+        if (androidExtension != null) {
+            val extensionClass = androidExtension.javaClass
+            try {
+                val namespaceMethod = extensionClass.getMethod("getNamespace")
+                val namespace = namespaceMethod.invoke(androidExtension) as? String
+                if (namespace.isNullOrEmpty()) {
+                    val setNamespaceMethod = extensionClass.getMethod("setNamespace", java.lang.String::class.java)
+                    val groupName = project.group.toString()
+                    val newNamespace = if (groupName.isNotEmpty()) groupName else "com.example.${project.name.replace("-", "_")}"
+                    setNamespaceMethod.invoke(androidExtension, newNamespace)
+                    println("Injected namespace $newNamespace into project ${project.name}")
+                }
+            } catch (e: Exception) {
+                // Ignore if getNamespace or setNamespace doesn't exist
+            }
+        }
+    }
 }
 
 tasks.register<Delete>("clean") {


### PR DESCRIPTION
this closes #1  

This fixes the AGP 8+ 'Namespace not specified' build failure caused by flutter_bluetooth_serial. By dynamically injecting the namespace in build.gradle.kts, this allows anyone cloning the repo to build the app immediately without requiring local package overrides.

Merge Order: Please merge this PR first so the build is fully unblocked.