### PR TITLE
refactor(core): isolate app initialization from main entrypoint

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'bluetooth/bluetooth_service.dart';
+import 'voice/voice_commands.dart';
+import 'screens/home_screen.dart';
+
+class SmartRoverApp extends StatelessWidget {
+  final BluetoothService bluetoothService;
+
+  const SmartRoverApp({super.key, required this.bluetoothService});
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider.value(value: bluetoothService),
+        ChangeNotifierProxyProvider<BluetoothService, VoiceCommandService>(
+          create: (_) => VoiceCommandService(bluetoothService),
+          update: (_, bt, prev) => prev ?? VoiceCommandService(bt),
+        ),
+      ],
+      child: MaterialApp(
+        title: 'Smart Rover',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(
+          colorScheme: const ColorScheme.dark(
+            surface: Color(0xFF1A1A1A),
+            onSurface: Colors.white,
+            primary: Color(0xFF3B7BE8),
+            onPrimary: Colors.white,
+          ),
+          scaffoldBackgroundColor: const Color(0xFF161616),
+          fontFamily: 'Roboto',
+          useMaterial3: true,
+          splashFactory: NoSplash.splashFactory,
+        ),
+        home: const HomeScreen(),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:provider/provider.dart';
 
+import 'app.dart';
 import 'bluetooth/bluetooth_service.dart';
-import 'screens/home_screen.dart';
-import 'voice/voice_commands.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -30,40 +28,4 @@ Future<void> main() async {
   }
 
   runApp(SmartRoverApp(bluetoothService: bluetoothService));
-}
-
-class SmartRoverApp extends StatelessWidget {
-  final BluetoothService bluetoothService;
-
-  const SmartRoverApp({super.key, required this.bluetoothService});
-
-  @override
-  Widget build(BuildContext context) {
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider.value(value: bluetoothService),
-        ChangeNotifierProxyProvider<BluetoothService, VoiceCommandService>(
-          create: (_) => VoiceCommandService(bluetoothService),
-          update: (_, bt, prev) => prev ?? VoiceCommandService(bt),
-        ),
-      ],
-      child: MaterialApp(
-        title: 'Smart Rover',
-        debugShowCheckedModeBanner: false,
-        theme: ThemeData(
-          colorScheme: const ColorScheme.dark(
-            surface: Color(0xFF1A1A1A),
-            onSurface: Colors.white,
-            primary: Color(0xFF3B7BE8),
-            onPrimary: Colors.white,
-          ),
-          scaffoldBackgroundColor: const Color(0xFF161616),
-          fontFamily: 'Roboto',
-          useMaterial3: true,
-          splashFactory: NoSplash.splashFactory,
-        ),
-        home: const HomeScreen(),
-      ),
-    );
-  }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:remote/bluetooth/bluetooth_service.dart';
-import 'package:remote/main.dart';
+import 'package:remote/app.dart';
 
 void main() {
   testWidgets('SmartRoverApp smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
this closes #2  

I pulled SmartRoverApp and the provider setup completely out of main.dart and moved them into a new file called app.dart.

main.dart is now strictly an entry point. It only handles the necessary hardware initialization and calls runApp(). This gets the project perfectly aligned with standard Flutter practices so the code is easier for others to navigate.

Merge Order: Please merge this PR second.