### PR TITLE
fix(bluetooth): load bonded devices when manager opens

### DIFF
--- a/lib/widgets/bluetooth_sheet.dart
+++ b/lib/widgets/bluetooth_sheet.dart
@@ -5,8 +5,22 @@ import 'package:flutter_bluetooth_serial/flutter_bluetooth_serial.dart';
 import '../bluetooth/bluetooth_service.dart';
 import '../theme/colors.dart';
 
-class BluetoothSheet extends StatelessWidget {
+class BluetoothSheet extends StatefulWidget {
   const BluetoothSheet({super.key});
+
+  @override
+  State<BluetoothSheet> createState() => _BluetoothSheetState();
+}
+
+class _BluetoothSheetState extends State<BluetoothSheet> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<BluetoothService>().loadBondedDevices();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/bluetooth_sheet.dart
+++ b/lib/widgets/bluetooth_sheet.dart
@@ -15,7 +15,7 @@ class BluetoothSheet extends StatefulWidget {
 class _BluetoothSheetState extends State<BluetoothSheet> {
   @override
   void initState() {
-    super.initState();
+    super.initState();  // Auto scan the devices when bluetooth sheet opens
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       context.read<BluetoothService>().loadBondedDevices();

--- a/lib/widgets/bluetooth_sheet.dart
+++ b/lib/widgets/bluetooth_sheet.dart
@@ -15,10 +15,10 @@ class BluetoothSheet extends StatefulWidget {
 class _BluetoothSheetState extends State<BluetoothSheet> {
   @override
   void initState() {
-    super.initState();  // Auto scan the devices when bluetooth sheet opens
+    super.initState();  // load the bounded devices
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      context.read<BluetoothService>().loadBondedDevices();
+      context.read<BluetoothService>().startDiscovery(); // auto scan the available devices
     });
   }
 


### PR DESCRIPTION
## Summary
This PR fixes a UX issue where paired (bonded) Bluetooth devices were not shown when opening the Bluetooth Manager until the user tapped Scan.

## Root Cause
Bonded devices were loaded only during the discovery flow (`startDiscovery`), so opening the bottom sheet could render an empty list before scanning.

## Changes Made
- Converted `BluetoothSheet` from `StatelessWidget` to `StatefulWidget`.
- Added `initState` in `_BluetoothSheetState`.
- Added a post-frame callback in `initState` to call `loadBondedDevices()` from `BluetoothService` when the sheet opens.
- Kept discovery flow unchanged so Scan behavior for non-bonded nearby devices still works.

## Files Changed
- `lib/widgets/bluetooth_sheet.dart`

## Behavior After This Change
- Opening Device Manager now loads and displays bonded devices immediately.
- Scan remains optional and continues to discover additional available devices.
fixes: #8 