### PR TITLE
feat: implement gyro tilt control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+.settings/
+local.properties
 
 # DevTools
 devtools_options.yaml

--- a/lib/animations/animations.dart
+++ b/lib/animations/animations.dart
@@ -404,3 +404,142 @@ class RadialDotHaloPainter extends CustomPainter {
   @override
   bool shouldRepaint(_) => false;
 }
+
+// ── Gyro Tilt Dot Matrix Animation ───────────────────────────────────────────
+/// Nothing OS–style dot-matrix tilt indicator for Gyro Mode.
+/// [tiltX] lateral tilt: -1 (left) … +1 (right)
+/// [tiltY] forward/back: -1 (back) … +1 (forward)
+class GyroTiltAnimation extends StatefulWidget {
+  final double tiltX;
+  final double tiltY;
+  const GyroTiltAnimation({
+    super.key,
+    required this.tiltX,
+    required this.tiltY,
+  });
+
+  @override
+  State<GyroTiltAnimation> createState() => _GyroTiltAnimationState();
+}
+
+class _GyroTiltAnimationState extends State<GyroTiltAnimation>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _ctrl,
+      builder: (context, child) => CustomPaint(
+        painter: _GyroTiltPainter(
+          tiltX: widget.tiltX,
+          tiltY: widget.tiltY,
+          pulse: _ctrl.value,
+        ),
+        size: const Size(140, 140),
+      ),
+    );
+  }
+}
+
+class _GyroTiltPainter extends CustomPainter {
+  final double tiltX;
+  final double tiltY;
+  final double pulse;
+
+  const _GyroTiltPainter({
+    required this.tiltX,
+    required this.tiltY,
+    required this.pulse,
+  });
+
+  static const int _cols = 11;
+  static const int _rows = 11;
+  static const double _spacing = 12.0;
+  static const double _dotR = 2.8;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final cx = size.width / 2;
+    final cy = size.height / 2;
+
+    final startX = cx - ((_cols - 1) / 2) * _spacing;
+    final startY = cy - ((_rows - 1) / 2) * _spacing;
+
+    final activeCol =
+        ((_cols - 1) / 2 + tiltX.clamp(-1.0, 1.0) * ((_cols - 1) / 2))
+            .round();
+    final activeRow =
+        ((_rows - 1) / 2 - tiltY.clamp(-1.0, 1.0) * ((_rows - 1) / 2))
+            .round();
+
+    for (int row = 0; row < _rows; row++) {
+      for (int col = 0; col < _cols; col++) {
+        final dx = startX + col * _spacing;
+        final dy = startY + row * _spacing;
+
+        final dC = (col - activeCol).abs();
+        final dR = (row - activeRow).abs();
+        final dist = math.sqrt((dC * dC + dR * dR).toDouble());
+
+        final bool isCenter = dC == 0 && dR == 0;
+        final bool isInner = dist <= 1.4;
+        final bool isMid = dist <= 2.5;
+
+        Color color;
+        double radius;
+        if (isCenter) {
+          final alpha = 0.7 + 0.3 * pulse;
+          color = AppTheme.accentRed.withValues(alpha: alpha);
+          radius = _dotR + 0.8;
+        } else if (isInner) {
+          color = AppTheme.accentRed.withValues(alpha: 0.55);
+          radius = _dotR;
+        } else if (isMid) {
+          color = AppTheme.accentRed.withValues(alpha: 0.2);
+          radius = _dotR - 0.4;
+        } else {
+          final alpha = math.max(0.05, 0.18 - dist * 0.02);
+          color = Colors.white.withValues(alpha: alpha);
+          radius = _dotR - 0.8;
+        }
+
+        canvas.drawCircle(Offset(dx, dy), radius, Paint()..color = color);
+      }
+    }
+
+    // Subtle crosshair axes
+    final axisPaint = Paint()
+      ..color = Colors.white.withValues(alpha: 0.08)
+      ..strokeWidth = 1;
+    canvas.drawLine(
+      Offset(startX, cy),
+      Offset(startX + (_cols - 1) * _spacing, cy),
+      axisPaint,
+    );
+    canvas.drawLine(
+      Offset(cx, startY),
+      Offset(cx, startY + (_rows - 1) * _spacing),
+      axisPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_GyroTiltPainter old) =>
+      old.tiltX != tiltX || old.tiltY != tiltY || old.pulse != pulse;
+}

--- a/lib/bluetooth/bluetooth_service.dart
+++ b/lib/bluetooth/bluetooth_service.dart
@@ -15,6 +15,10 @@ class BluetoothService extends ChangeNotifier {
   static const String cmdBackward = 'D';
   static const String cmdLeft = 'L';
   static const String cmdRight = 'R';
+  static const String cmdForwardLeft = 'G';
+  static const String cmdForwardRight = 'I';
+  static const String cmdBackwardLeft = 'H';
+  static const String cmdBackwardRight = 'J';
   static const String cmdStop = 'S';
   static const String cmdModeManual = 'MODE_MANUAL';
   static const String cmdModeObstacle = 'MODE_OBSTACLE';

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import 'package:sensors_plus/sensors_plus.dart';
 
 import '../bluetooth/bluetooth_service.dart';
 import '../voice/voice_commands.dart';
@@ -27,6 +29,17 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _backActive = false;
   bool _leftActive = false;
   bool _rightActive = false;
+
+  // ── Gyro Mode ──────────────────────────────────────────────────────────────
+  bool _gyroMode = false;
+  double _gyroTiltX = 0.0; // -1 left … +1 right
+  double _gyroTiltY = 0.0; // -1 back  … +1 forward
+  String _lastGyroCmd = '';
+  StreamSubscription<AccelerometerEvent>? _accelSub;
+
+  static const double _gyroDeadzone = 2.5; // m/s² threshold
+  static const double _gyroMax = 7.0;      // clamp range
+  // ──────────────────────────────────────────────────────────────────────────
 
   final LayerLink _layerLink = LayerLink();
   OverlayEntry? _overlayEntry;
@@ -172,8 +185,104 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
+  // ── Gyro Mode helpers ─────────────────────────────────────────────────────
+  void _startGyro() {
+    final bt = context.read<BluetoothService>();
+    _accelSub = accelerometerEventStream().listen((AccelerometerEvent e) {
+      // In LANDSCAPE mode:
+      // e.x: Longitudinal tilt (forward/back)
+      // e.y: Lateral tilt (left/right)
+
+      // INVERTED: User said forward tilt resulted in "down" behavior.
+      // So we flip the sign of rawFwdBack.
+      final rawFwdBack = -e.x; 
+      final rawLeftRight = e.y;
+
+      // Update UI tilt values (normalized -1 to 1)
+      final normY = (rawFwdBack.clamp(-_gyroMax, _gyroMax) / _gyroMax);
+      final normX = (rawLeftRight.clamp(-_gyroMax, _gyroMax) / _gyroMax);
+
+      if (!mounted) return;
+      setState(() {
+        _gyroTiltX = normX;
+        _gyroTiltY = normY;
+      });
+
+      String cmd;
+
+      final bool isFwd = rawFwdBack > _gyroDeadzone;
+      final bool isBk = rawFwdBack < -_gyroDeadzone;
+      final bool isRt = rawLeftRight > _gyroDeadzone;
+      final bool isLt = rawLeftRight < -_gyroDeadzone;
+
+      if (isFwd && isLt) {
+        cmd = BluetoothService.cmdForwardLeft;
+      } else if (isFwd && isRt) {
+        cmd = BluetoothService.cmdForwardRight;
+      } else if (isBk && isLt) {
+        cmd = BluetoothService.cmdBackwardLeft;
+      } else if (isBk && isRt) {
+        cmd = BluetoothService.cmdBackwardRight;
+      } else if (isFwd) {
+        cmd = BluetoothService.cmdForward;
+      } else if (isBk) {
+        cmd = BluetoothService.cmdBackward;
+      } else if (isLt) {
+        cmd = BluetoothService.cmdLeft;
+      } else if (isRt) {
+        cmd = BluetoothService.cmdRight;
+      } else {
+        cmd = BluetoothService.cmdStop;
+      }
+
+      if (cmd != _lastGyroCmd) {
+        bt.sendCommand(cmd);
+        _lastGyroCmd = cmd;
+
+        // Update button visual states to reflect 8-direction tilt
+        if (!mounted) return;
+        setState(() {
+          _fwdActive = isFwd;
+          _backActive = isBk;
+          _leftActive = isLt;
+          _rightActive = isRt;
+        });
+      }
+    });
+  }
+
+  void _stopGyro() {
+    _accelSub?.cancel();
+    _accelSub = null;
+    context.read<BluetoothService>().sendCommand(BluetoothService.cmdStop);
+    setState(() {
+      _gyroTiltX = 0.0;
+      _gyroTiltY = 0.0;
+      _lastGyroCmd = '';
+      // Reset button states
+      _fwdActive = false;
+      _backActive = false;
+      _leftActive = false;
+      _rightActive = false;
+    });
+  }
+
+  void _toggleGyroMode() {
+    HapticFeedback.mediumImpact();
+    setState(() => _gyroMode = !_gyroMode);
+    if (_gyroMode) {
+      _startGyro();
+      _showSnack('Gyro Mode ON — tilt to drive');
+    } else {
+      _stopGyro();
+      _showSnack('Gyro Mode OFF');
+    }
+  }
+  // ──────────────────────────────────────────────────────────────────────────
+
   @override
   void dispose() {
+    _accelSub?.cancel();
     _overlayEntry?.remove();
     super.dispose();
   }
@@ -183,74 +292,110 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       backgroundColor: AppTheme.bg,
-      body: Stack(
-        children: [
-          const Positioned.fill(child: DotGrid()),
-          SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-              child: Column(
-                children: [
-                  TopBar(
-                    onBluetoothTap: _showBluetooth,
-                    onPowerTap: () {
-                      final bt = context.read<BluetoothService>();
-                      if (bt.isConnected) {
-                        bt.disconnect();
-                        _showSnack('Bluetooth disconnected');
-                      } else {
-                        _showSnack('Not connected');
-                      }
-                    },
-                  ),
-                  const SizedBox(height: 14),
-                  Expanded(
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        // LEFT PANEL: FWD / BACK
-                        Expanded(flex: 5, child: _buildFwdBackPanel()),
-                        const SizedBox(width: 20),
-
-                        // CENTER: Animation + Mode
-                        Expanded(
-                          flex: 6,
-                          child: Column(
-                            children: [
-                              Expanded(child: _centerCar()),
-                              const SizedBox(height: 10),
-                              FittedBox(
-                                fit: BoxFit.scaleDown,
-                                child: Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    _modeButton(),
-                                    if (_activeMode == 'Obstacle Avoiding' ||
-                                        _activeMode == 'Human Following') ...[
-                                      const SizedBox(width: 12),
-                                      _startStopButton(),
-                                    ] else if (_activeMode == 'Voice Control') ...[
-                                      const SizedBox(width: 12),
-                                      _voiceMicButton(),
-                                    ],
-                                  ],
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-
-                        const SizedBox(width: 20),
-                        // RIGHT PANEL: LEFT / RIGHT
-                        Expanded(flex: 5, child: _buildLeftRightPanel()),
-                      ],
+      body: GestureDetector(
+        // Left swipe on the home screen toggles Gyro Mode
+        onHorizontalDragEnd: (details) {
+          if (details.primaryVelocity != null &&
+              details.primaryVelocity! < -400) {
+            _toggleGyroMode();
+          }
+        },
+        child: Stack(
+          children: [
+            const Positioned.fill(child: DotGrid()),
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 20, vertical: 12),
+                child: Column(
+                  children: [
+                    TopBar(
+                      onBluetoothTap: _showBluetooth,
+                      onPowerTap: () {
+                        final bt = context.read<BluetoothService>();
+                        if (bt.isConnected) {
+                          bt.disconnect();
+                          _showSnack('Bluetooth disconnected');
+                        } else {
+                          _showSnack('Not connected');
+                        }
+                      },
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 14),
+                    Expanded(
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          // LEFT PANEL: FWD / BACK (disabled in gyro mode)
+                          Expanded(
+                            flex: 5,
+                            child: IgnorePointer(
+                              ignoring: _gyroMode,
+                              child: AnimatedOpacity(
+                                opacity: _gyroMode ? 0.6 : 1.0,
+                                duration: const Duration(milliseconds: 300),
+                                child: _buildFwdBackPanel(),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 20),
+
+                          // CENTER: Animation + Mode
+                          Expanded(
+                            flex: 6,
+                            child: Column(
+                              children: [
+                                Expanded(child: _centerCar()),
+                                const SizedBox(height: 10),
+                                FittedBox(
+                                  fit: BoxFit.scaleDown,
+                                  child: Row(
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.center,
+                                    children: [
+                                      _modeButton(),
+                                      if (!_gyroMode) ...[
+                                        if (_activeMode ==
+                                                'Obstacle Avoiding' ||
+                                            _activeMode ==
+                                                'Human Following') ...[
+                                          const SizedBox(width: 12),
+                                          _startStopButton(),
+                                        ] else if (_activeMode ==
+                                            'Voice Control') ...[
+                                          const SizedBox(width: 12),
+                                          _voiceMicButton(),
+                                        ],
+                                      ],
+                                    ],
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+
+                          const SizedBox(width: 20),
+                          // RIGHT PANEL: LEFT / RIGHT (disabled in gyro mode)
+                          Expanded(
+                            flex: 5,
+                            child: IgnorePointer(
+                              ignoring: _gyroMode,
+                              child: AnimatedOpacity(
+                                opacity: _gyroMode ? 0.6 : 1.0,
+                                duration: const Duration(milliseconds: 300),
+                                child: _buildLeftRightPanel(),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -365,7 +510,10 @@ class _HomeScreenState extends State<HomeScreen> {
               child: CustomPaint(painter: const RadialDotHaloPainter()),
             ),
 
-            if (showVoiceWave)
+            // Gyro Mode takes precedence
+            if (_gyroMode)
+              GyroTiltAnimation(tiltX: _gyroTiltX, tiltY: _gyroTiltY)
+            else if (showVoiceWave)
               const DotMatrixVoiceAnimation()
             else if (_activeMode == 'Obstacle Avoiding')
               RadarDotAnimation(isActive: _isModeRunning)
@@ -374,11 +522,32 @@ class _HomeScreenState extends State<HomeScreen> {
             else
               const NormalDotAnimation(),
 
+            // Gyro mode label
+            if (_gyroMode)
+              Positioned(
+                bottom: 5,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: AppTheme.accentRed.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: const Text(
+                    'GYRO MODE: TILT TO DRIVE',
+                    style: TextStyle(
+                      color: AppTheme.accentRed,
+                      fontSize: 8,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 1.2,
+                    ),
+                  ),
+                ),
+              )
             // Voice status text
-            if (_activeMode == 'Voice Control' &&
+            else if (_activeMode == 'Voice Control' &&
                 voiceService.statusMessage.isNotEmpty)
               Positioned(
-                bottom: -20,
+                bottom: 0,
                 child: Text(
                   voiceService.statusMessage.toUpperCase(),
                   style: const TextStyle(

--- a/lib/widgets/top_bar.dart
+++ b/lib/widgets/top_bar.dart
@@ -55,13 +55,19 @@ class TopBar extends StatelessWidget {
             children: [
               const DotCluster(),
               const SizedBox(width: 10),
-              Text(
-                'RC REMOTE',
-                style: GoogleFonts.dotGothic16(
-                  color: AppTheme.accentRed,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w700,
-                  letterSpacing: 2.5,
+              Expanded(
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    'RC REMOTE',
+                    style: GoogleFonts.dotGothic16(
+                      color: AppTheme.accentRed,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 2.5,
+                    ),
+                  ),
                 ),
               ),
             ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -480,6 +480,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  sensors_plus:
+    dependency: "direct main"
+    description:
+      name: sensors_plus
+      sha256: "89e2bfc3d883743539ce5774a2b93df61effde40ff958ecad78cd66b1a8b8d52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.2"
+  sensors_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: sensors_plus_platform_interface
+      sha256: "58815d2f5e46c0c41c40fb39375d3f127306f7742efe3b891c0b1c87e2b5cd5d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   permission_handler: ^12.0.1
   google_fonts: ^8.0.2
   shared_preferences: ^2.5.5
+  sensors_plus: ^6.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Overview
This PR implements the requested Gyro Mode (#14), providing tilt-based car control with a premium Nothing OS-inspired aesthetic.

## Changes
- **Sensor Integration**: Added `sensors_plus` and implemented a longitudinal/lateral tilt listener.
- **Navigation**: Wrapped `HomeScreen` in a `GestureDetector` to toggle Gyro Mode via a **left swipe**.
- **8-Directional Control**: Enhanced the core logic to support diagonal movement (Forward-Left, Forward-Right, etc.) sending standard commands (`G`, `I`, `H`, `J`).
- **Dynamic UI**: 
    - Added a custom **Dot Matrix tilt indicator** animation in the center panel.
    - Synchronized the on-screen direction buttons to light up based on phone tilt.
    - Faded and disabled manual touch controls when Gyro Mode is active.
- **Fixes**: Resolved a horizontal overflow issue in the `TopBar` for landscape devices.

## Verification
Tested on physical hardware:
- Left swipe toggles mode correctly.
- Tilt accurately sends U/D/L/R and diagonal G/I/H/J commands.
- Buttons reflect tilt state instantly.
- No UI overflows in landscape.
