### PR TITLE
fix: update MaterialApp title from 'Smart Rover' to 'RC Remote' 

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -21,7 +21,7 @@ class SmartRoverApp extends StatelessWidget {
         ),
       ],
       child: MaterialApp(
-        title: 'Smart Rover',
+        title: 'RC Remote',
         debugShowCheckedModeBanner: false,
         theme: ThemeData(
           colorScheme: const ColorScheme.dark(


### PR DESCRIPTION
#68 